### PR TITLE
Corrige o comando 'data' do Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ run:
 	@python manage.py runserver 0.0.0.0:8000
 
 data:
-	@python manage.py syncdb
+	@python manage.py migrate
 
 initial_data:
 	@python manage.py countries


### PR DESCRIPTION
O comando `syncdb` foi removido no [django 1.9](https://docs.djangoproject.com/en/dev/releases/1.9/#features-removed-in-1-9), o comando correto agora é o `migrate`. 